### PR TITLE
Externalize dependency-check/Change used JDK version

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       runner-os: 'ubuntu-latest'
       java-distribution: 'temurin'
-      java-version: 17
+      java-version: 21
     secrets:
       nvd-api-key: ${{ secrets.NVD_API_KEY }}
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -10,54 +10,11 @@ on:
 
 jobs:
   check-dependencies:
-    name: Check dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          show-progress: false
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Cache NVD DB
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository/org/owasp/dependency-check-data/
-          key: dependency-check-${{ github.run_id }}
-          restore-keys: |
-            dependency-check
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
-      - name: Run org.owasp:dependency-check plugin
-        id: dependency-check
-        continue-on-error: true
-        run: mvn -B validate -Pdependency-check
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-      - name: Upload report on failure
-        if: steps.dependency-check.outcome == 'failure'
-        uses: actions/upload-artifact@v3
-        with:
-          name: dependency-check-report
-          path: target/dependency-check-report.html
-          if-no-files-found: error
-      - name: Slack Notification on regular check
-        if: github.event_name == 'schedule' && steps.dependency-check.outcome == 'failure'
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_USERNAME: 'Cryptobot'
-          SLACK_ICON: false
-          SLACK_ICON_EMOJI: ':bot:'
-          SLACK_CHANNEL: 'cryptomator-desktop'
-          SLACK_TITLE: "Vulnerabilities in ${{ github.event.repository.name }} detected."
-          SLACK_MESSAGE: "Download the <https://github.com/${{ github.repository }}/actions/run/${{ github.run_id }}|report> for more details."
-          SLACK_FOOTER: false
-          MSG_MINIMAL: true
-      - name: Failing workflow on release branch
-        if: github.event_name == 'push' && steps.dependency-check.outcome == 'failure'
-        shell: bash
-        run: exit 1
+    uses: skymatic/workflows/.github/workflows/run-dependency-check.yml@v1
+    with:
+      runner-os: 'ubuntu-latest'
+      java-distribution: 'temurin'
+      java-version: 17
+    secrets:
+      nvd-api-key: ${{ secrets.NVD_API_KEY }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This PR moves the dependency-check to the [skymatic/workflows](https://github.com/skymatic/workflows/) project, namely [run-dependency-check.yml](https://github.com/skymatic/workflows/blob/v1/.github/workflows/run-dependency-check.yml)

Also see: https://github.com/cryptomator/cryptolib/pull/45
Also see for info about versioning: https://github.com/cryptomator/cryptolib/pull/46, https://github.com/cryptomator/cryptofs/pull/202#discussion_r1453615249 and https://github.com/skymatic/workflows/pull/1

Current workflow SHA at time of PR: https://github.com/skymatic/workflows/commit/4f0a5196ff35295c1a15a97e0e1632682e7e47ab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
    - Updated the dependency check workflow to utilize an external workflow for improved efficiency and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->